### PR TITLE
Pin transformers to a Qwen3-VL-compatible version range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "S-Lab-1.0"
 requires-python = ">=3.10"
 dependencies = [
     "torch>=2.2",
-    "transformers>=4.40",
+    "transformers>=4.57.3,<5.3.0",
     "diffusers>=0.25",
     "accelerate",
     "pillow>=9.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # for VLANeXt
 huggingface_hub
-transformers
+transformers>=4.57.3,<5.3.0
 diffusers
 datasets
 accelerator


### PR DESCRIPTION
## Summary

This PR constrains the `transformers` dependency to a Qwen3-VL-compatible range in both `pyproject.toml` and `requirements.txt`.

## Motivation

Training currently fails with newer `transformers` releases because the Qwen3-VL integration in this repo still uses the older `get_rope_index(...)` call path.

Starting from `transformers>=5.3.0`, `Qwen3VLModel.get_rope_index()` requires `mm_token_type_ids`, but the current code does not pass that argument through the training/model pipeline. As a result, training crashes with:

```python
TypeError: Qwen3VLModel.get_rope_index() missing 1 required positional argument: 'mm_token_type_ids'