### PR TITLE
fix: use valid SPDX license expression in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "vlanext"
 version = "0.1.0"
 description = "VLANeXt: Recipes for Building Strong VLA Models"
 readme = "README.md"
-license = "S-Lab-1.0"
+license = "LicenseRef-S-Lab-1.0"
 requires-python = ">=3.10"
 dependencies = [
     "torch>=2.2",


### PR DESCRIPTION
## Summary
- Changes `license = "S-Lab-1.0"` to `license = "LicenseRef-S-Lab-1.0"` in pyproject.toml

## Motivation
`S-Lab-1.0` is not a recognized SPDX identifier, so setuptools (68/74/current) rejects the package during `pip install` or `uv pip install` from a git URL. Per [PEP 639](https://peps.python.org/pep-0639/), custom licenses should use the `LicenseRef-` prefix.

This is a one-line fix that unblocks installing VLANeXt as a dependency in downstream projects (e.g., [vla-evaluation-harness#34](https://github.com/allenai/vla-evaluation-harness/pull/34)).